### PR TITLE
Incrementing plugin version to 1.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
 	<artifactId>play-autotest-plugin</artifactId>
 	<name>Play!Framework plugin</name>
-	<version>0.2.1</version>
+	<version>1.0.0</version>
 	<packaging>hpi</packaging>
 	<url>https://wiki.jenkins-ci.org/display/JENKINS/play-plugin</url>
 	<distributionManagement>


### PR DESCRIPTION
Since the plugin was entirely replaced, it is more reasonable to release it as a major version.